### PR TITLE
Reorder elements in debian package naming

### DIFF
--- a/debian/debian.go
+++ b/debian/debian.go
@@ -86,8 +86,8 @@ func (d *Debian) createControl() (err error) {
 	data := ""
 
 	data += fmt.Sprintf("Package: %s\n", d.Pack.PkgName)
-	data += fmt.Sprintf("Version: %s-0%s%s~%s\n",
-		d.Pack.PkgVer, d.Pack.Distro, d.Pack.PkgRel, d.Pack.Release)
+	data += fmt.Sprintf("Version: %s-%s%s~%s\n",
+		d.Pack.PkgVer, d.Pack.PkgRel, d.Pack.Distro, d.Pack.Release)
 	data += fmt.Sprintf("Architecture: %s\n", d.Pack.Arch)
 	data += fmt.Sprintf("Maintainer: %s\n", d.Pack.Maintainer)
 	data += fmt.Sprintf("Installed-Size: %d\n", d.installSize)
@@ -205,8 +205,8 @@ func (d *Debian) dpkgDeb() (err error) {
 	_, dir := filepath.Split(filepath.Clean(d.Pack.PackageDir))
 	path := filepath.Join(d.Pack.Root, dir+".deb")
 	newPath := filepath.Join(d.Pack.Home,
-		fmt.Sprintf("%s_%s-0%s%s.%s_%s.deb",
-			d.Pack.PkgName, d.Pack.PkgVer, d.Pack.Distro, d.Pack.PkgRel,
+		fmt.Sprintf("%s_%s-%s%s.%s_%s.deb",
+			d.Pack.PkgName, d.Pack.PkgVer, d.Pack.PkgRel, d.Pack.Distro,
 			d.Pack.Release, d.Pack.Arch))
 
 	os.Remove(newPath)


### PR DESCRIPTION
Debian uses package notation `pkgname_pkgver-pkgrel`.
I think it would be grate to remove useless zero.
Maybe we should do more and remove distro and release like 
```
version: pkgname_pkgver-pkgrel
filename: pkgname_pkgver-pkgrel_arch.deb
```