### PR TITLE
Fix copy-paste mistake in control file

### DIFF
--- a/debian/debian.go
+++ b/debian/debian.go
@@ -97,7 +97,7 @@ func (d *Debian) createControl() (err error) {
 			strings.Join(d.Pack.Depends, ", "))
 	}
 
-	if len(d.Pack.Depends) > 0 {
+	if len(d.Pack.Conflicts) > 0 {
 		data += fmt.Sprintf("Conflicts: %s\n",
 			strings.Join(d.Pack.Conflicts, ", "))
 	}


### PR DESCRIPTION
This error causes adding `Conflicts:` if depends are not empty and conflicts are empty.
It breaks debian jessie.