### PR TITLE
replace go get with go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ build() {
     export GOPATH="${srcdir}/go"
     mv "${pkgname}-${pkgver}" "go/src"
     cd "go/src/${pkgname}-${pkgver}"
-    go get
+    go install
     go build -a
 }
 
@@ -244,18 +244,18 @@ package() {
 ### project example
 
 A project can be created with the cli tools which can be installed using
-go get. The packages can be built and added to the repo. An example project is
+`go install`. The packages can be built and added to the repo. An example project is
 available in the example directory. The `pull` command should be run before
 all builds to update the docker images used for builds.
 
 ```
-$ go get github.com/pacur/pacur
+$ go install github.com/pacur/pacur@latest
 $ cd example
 $ pacur pull
 $ pacur project init
 $ pacur project build
 $ pacur project repo
-$ go get github.com/pacur/httpserver
+$ go install github.com/pacur/httpserver@latest
 $ cd mirror
 $ httpserver --port 80
 ```


### PR DESCRIPTION
`go get` has been deprecated in go 1.17 and removed in `1.18` and so doesn't work as of today

cf. https://stackoverflow.com/questions/30295146/how-can-i-install-a-package-with-go-get#answer-68809471