### PR TITLE
Run makepkg with --nodeps

### DIFF
--- a/pacman/pacman.go
+++ b/pacman/pacman.go
@@ -204,7 +204,7 @@ func (p *Pacman) pacmanBuild() (err error) {
 		return
 	}
 
-	err = utils.Exec(p.pacmanDir, "sudo", "-u", "nobody", "makepkg")
+	err = utils.Exec(p.pacmanDir, "sudo", "-u", "nobody", "makepkg", "--nodeps")
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Without this running

```
sudo podman run --rm -it -v $PWD:/pacur pacur/archlinux
```

will fail as the dependencies are not installed in the container.