### PR TITLE
Fix for Dockerfile smell DL4000

### DIFF
--- a/docker/amazonlinux-2/Dockerfile
+++ b/docker/amazonlinux-2/Dockerfile
@@ -1,5 +1,5 @@
 FROM docker.io/amazonlinux:2
-MAINTAINER Pacur <contact@pacur.org>
+LABEL maintainer="Pacur <contact@pacur.org>" 
 
 RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 RUN yum -y upgrade


### PR DESCRIPTION
Hi!
The Dockerfile placed at "docker/amazonlinux-2/Dockerfile" contains the best practice violation [DL4000](https://github.com/hadolint/hadolint/wiki/DL4000) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL4000 occurs when the deprecated MAINTAINER instruction is used.
In this pull request, we propose a fix for that smell generated by our fixing tool. We verified that the patch is correct before opening the pull request.
To fix this smell, specifically, the MAINTAINER instruction is replaced by an equivalent LABEL instruction as recommended by the official guidelines.

This change is only aimed at fixing that specific smell. In the case the fix is not valid or useful, please briefly indicate the reason along with suggestions for possible improvements.

Thanks in advance.