### PR TITLE
Dependency restrictions

### DIFF
--- a/debian/debian.go
+++ b/debian/debian.go
@@ -22,7 +22,7 @@ func DependString(dependency pack.Dependency) string {
 	if dependency.Restriction == nil {
 		return dependency.Name
 	} else {
-		return fmt.Sprintf("%s (%s)", dependency.Name, *dependency.Restriction)
+		return fmt.Sprintf("%s (%s %s)", dependency.Name, dependency.Restriction.Comparison, dependency.Restriction.Version)
 	}
 }
 

--- a/debian/debian.go
+++ b/debian/debian.go
@@ -18,6 +18,25 @@ type Debian struct {
 	sums        string
 }
 
+func DependString(dependency pack.Dependency) string {
+	if dependency.Restriction == nil {
+		return dependency.Name
+	} else {
+		return fmt.Sprintf("%s (%s)", dependency.Name, *dependency.Restriction)
+	}
+}
+
+func DependsString(dependencies []pack.Dependency) string {
+	var result string
+	for i, d := range dependencies {
+		if i > 0 {
+			result += ", "
+		}
+		result += DependString(d)
+	}
+	return result
+}
+
 func (d *Debian) getDepends() (err error) {
 	if len(d.Pack.MakeDepends) == 0 {
 		return
@@ -32,7 +51,9 @@ func (d *Debian) getDepends() (err error) {
 		"--assume-yes",
 		"install",
 	}
-	args = append(args, d.Pack.MakeDepends...)
+	for _, d := range d.Pack.MakeDepends {
+		args = append(args, DependString(d))
+	}
 
 	err = utils.Exec("", "apt-get", args...)
 	if err != nil {
@@ -94,8 +115,7 @@ func (d *Debian) createControl() (err error) {
 	data += fmt.Sprintf("Installed-Size: %d\n", d.installSize)
 
 	if len(d.Pack.Depends) > 0 {
-		data += fmt.Sprintf("Depends: %s\n",
-			strings.Join(d.Pack.Depends, ", "))
+		data += fmt.Sprintf("Depends: %s\n", DependsString(d.Pack.Depends))
 	}
 
 	if len(d.Pack.Conflicts) > 0 {
@@ -104,8 +124,7 @@ func (d *Debian) createControl() (err error) {
 	}
 
 	if len(d.Pack.OptDepends) > 0 {
-		data += fmt.Sprintf("Recommends: %s\n",
-			strings.Join(d.Pack.OptDepends, ", "))
+		data += fmt.Sprintf("Recommends: %s\n", DependsString(d.Pack.OptDepends))
 	}
 
 	data += fmt.Sprintf("Section: %s\n", d.Pack.Section)

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -7,9 +7,14 @@ import (
 	"strings"
 )
 
+type DependencyRestriction struct {
+	Comparison string
+	Version string
+}
+
 type Dependency struct {
 	Name        string
-	Restriction *string
+	Restriction *DependencyRestriction
 }
 
 type Pack struct {
@@ -117,18 +122,32 @@ func (p *Pack) parseDirective(input string) (key string, pry int, err error) {
 }
 
 func ParseDependency(dependency string) Dependency {
+	comparisonStart := -1
+	comparisonEnd := -1
 	for i, c := range dependency {
 		if c == '=' || c == '<' || c == '>' {
-			var restriction = dependency[i:]
-			return Dependency {
-				Name: dependency[:i],
-				Restriction: &restriction,
+			if comparisonStart == -1 {
+				comparisonStart = i
+			}
+		} else {
+			if comparisonStart != -1 {
+				comparisonEnd = i
 			}
 		}
 	}
+
+	name := dependency
+	var restriction *DependencyRestriction
+	if comparisonEnd != -1 {
+		name = dependency[:comparisonStart]
+		restriction = &DependencyRestriction {
+			Comparison: dependency[comparisonStart:comparisonEnd],
+			Version: dependency[comparisonEnd:],
+		}
+	}
 	return Dependency {
-		Name: dependency,
-		Restriction: nil,
+		Name: name,
+		Restriction: restriction,
 	}
 }
 

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -132,6 +132,7 @@ func ParseDependency(dependency string) Dependency {
 		} else {
 			if comparisonStart != -1 {
 				comparisonEnd = i
+				break
 			}
 		}
 	}

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -9,7 +9,7 @@ import (
 
 type DependencyRestriction struct {
 	Comparison string
-	Version string
+	Version    string
 }
 
 type Dependency struct {
@@ -141,13 +141,13 @@ func ParseDependency(dependency string) Dependency {
 	var restriction *DependencyRestriction
 	if comparisonEnd != -1 {
 		name = dependency[:comparisonStart]
-		restriction = &DependencyRestriction {
+		restriction = &DependencyRestriction{
 			Comparison: dependency[comparisonStart:comparisonEnd],
-			Version: dependency[comparisonEnd:],
+			Version:    dependency[comparisonEnd:],
 		}
 	}
-	return Dependency {
-		Name: name,
+	return Dependency{
+		Name:        name,
 		Restriction: restriction,
 	}
 }
@@ -163,8 +163,8 @@ func ParseDependencies(dependencies []string) []Dependency {
 func (p *Pack) Resolve() (err error) {
 	reslv := resolver.New()
 
-	var dependsRaw     []string
-	var optDependsRaw  []string
+	var dependsRaw []string
+	var optDependsRaw []string
 	var makeDependsRaw []string
 
 	reslv.AddList("targets", p.Targets)

--- a/pacman/pacman.go
+++ b/pacman/pacman.go
@@ -16,6 +16,14 @@ type Pacman struct {
 	pacmanDir string
 }
 
+func DependString(dependency pack.Dependency) string {
+	if dependency.Restriction == nil {
+		return dependency.Name
+	} else {
+		return dependency.Name + *dependency.Restriction
+	}
+}
+
 func (p *Pacman) getDepends() (err error) {
 	if len(p.Pack.MakeDepends) == 0 {
 		return
@@ -30,7 +38,9 @@ func (p *Pacman) getDepends() (err error) {
 		"-S",
 		"--noconfirm",
 	}
-	args = append(args, p.Pack.MakeDepends...)
+	for _, d := range p.Pack.MakeDepends {
+		args = append(args, DependString(d))
+	}
 
 	err = utils.Exec("", "pacman", args...)
 	if err != nil {
@@ -131,7 +141,7 @@ func (p *Pacman) createMake() (err error) {
 	if len(p.Pack.Depends) > 0 {
 		data += "depends=(\n"
 		for _, item := range p.Pack.Depends {
-			data += fmt.Sprintf("    %s\n", strconv.Quote(item))
+			data += fmt.Sprintf("    %s\n", strconv.Quote(DependString(item)))
 		}
 		data += ")\n"
 	}
@@ -139,7 +149,7 @@ func (p *Pacman) createMake() (err error) {
 	if len(p.Pack.OptDepends) > 0 {
 		data += "optdepends=(\n"
 		for _, item := range p.Pack.OptDepends {
-			data += fmt.Sprintf("    %s\n", strconv.Quote(item))
+			data += fmt.Sprintf("    %s\n", strconv.Quote(DependString(item)))
 		}
 		data += ")\n"
 	}

--- a/pacman/pacman.go
+++ b/pacman/pacman.go
@@ -20,7 +20,7 @@ func DependString(dependency pack.Dependency) string {
 	if dependency.Restriction == nil {
 		return dependency.Name
 	} else {
-		return dependency.Name + *dependency.Restriction
+		return fmt.Sprintf("%s%s%s", dependency.Name, dependency.Restriction.Comparison, dependency.Restriction.Version)
 	}
 }
 

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -191,7 +191,7 @@ func File(distro, release, home string) (pac *pack.Pack, err error) {
 					err = &SyntaxError{
 						errors.Newf(
 							"parse: Unexpected char '%s' expected "+
-							"'\"' or '`' (%d: %s)", val[:1], n, line),
+								"'\"' or '`' (%d: %s)", val[:1], n, line),
 					}
 					return
 				}

--- a/redhat/redhat.go
+++ b/redhat/redhat.go
@@ -68,7 +68,7 @@ func DependString(dependency pack.Dependency) string {
 	if dependency.Restriction == nil {
 		return dependency.Name
 	} else {
-		return fmt.Sprintf("%s %s", dependency.Name, *dependency.Restriction)
+		return dependency.Name + *dependency.Restriction
 	}
 }
 

--- a/redhat/redhat.go
+++ b/redhat/redhat.go
@@ -64,6 +64,14 @@ func (r *Redhat) getRpmPath() (path string, err error) {
 	return
 }
 
+func DependString(dependency pack.Dependency) string {
+	if dependency.Restriction == nil {
+		return dependency.Name
+	} else {
+		return fmt.Sprintf("%s %s", dependency.Name, *dependency.Restriction)
+	}
+}
+
 func (r *Redhat) getDepends() (err error) {
 	if len(r.Pack.MakeDepends) == 0 {
 		return
@@ -73,7 +81,9 @@ func (r *Redhat) getDepends() (err error) {
 		"-y",
 		"install",
 	}
-	args = append(args, r.Pack.MakeDepends...)
+	for _, d := range r.Pack.MakeDepends {
+		args = append(args, DependString(d))
+	}
 
 	err = utils.Exec("", "yum", args...)
 	if err != nil {
@@ -173,11 +183,11 @@ func (r *Redhat) createSpec(files []string) (err error) {
 	}
 
 	for _, pkg := range r.Pack.Depends {
-		data += fmt.Sprintf("Requires: %s\n", pkg)
+		data += fmt.Sprintf("Requires: %s\n", DependString(pkg))
 	}
 
 	for _, pkg := range r.Pack.MakeDepends {
-		data += fmt.Sprintf("BuildRequires: %s\n", pkg)
+		data += fmt.Sprintf("BuildRequires: %s\n", DependString(pkg))
 	}
 
 	data += "\n"

--- a/redhat/redhat.go
+++ b/redhat/redhat.go
@@ -68,7 +68,7 @@ func DependString(dependency pack.Dependency) string {
 	if dependency.Restriction == nil {
 		return dependency.Name
 	} else {
-		return dependency.Name + *dependency.Restriction
+		return fmt.Sprintf("%s %s %s", dependency.Name, dependency.Restriction.Comparison, dependency.Restriction.Version)
 	}
 }
 


### PR DESCRIPTION
Add support for dependencies with extra restrictions such as `depends=("foo>=2.0")`.

Such a package restriction needs to be specified as:
| Distro | Dependency     |
|--------|----------------|
| Arch   | `foo>=2.0`     |
| Debian | `foo (>= 2.0)` |
| Redhat | `foo >= 2.0`   |
